### PR TITLE
corrected file name to run freecli

### DIFF
--- a/wiki/00_home.md
+++ b/wiki/00_home.md
@@ -26,7 +26,8 @@ go build -o freecli -x freecli.go
 Run it in sudo mode, QoS and gNB modules requires sudo privileges
 
 ```bash
-sudo ./cli
+cd freecli
+sudo ./freecli
 ```
 
 ## Configuration of Freecli


### PR DESCRIPTION
In the wiki there was a spelling mistake in the command to run the freecli, it was  "feecli"
also, we have to cd to freecli folder in the free5g-cli directory to be able to run the project